### PR TITLE
typo in example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $post_data = ['user' => 'bob', 'token' => 'dQw4w9WgXcQ']; //set to NULL if not u
 $user_data = ['foo', $whatever];
 $options = [CURLOPT_FOLLOWLOCATION => false];
 
-$RCX->addRequest($url, $post_data, 'callback_functn' $user_data, $options, $headers);
+$RCX->addRequest($url, $post_data, 'callback_functn', $user_data, $options, $headers);
 ```
 
 The callback function should look like this:


### PR DESCRIPTION
A comma was missing in the example. It should be:
$RCX->addRequest($url, $post_data, 'callback_functn', $user_data, $options, $headers);
