### PR TITLE
Fixed issues 19, 20 and properly fixed 9.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Rolling Curl X is a fork of Rolling Curl wrapper cURL Multi. It aims at making concurrent http requests in PHP as easy as possible.
 
+### Issues 19 and 20 fixed in this version plus proper fix of closed issue 9.
 
 ####License
 MIT


### PR DESCRIPTION
Fixes the 2 open issues 19 (timeout saved in sec, but then divided by 1000 later), 20 (`isset` used instead of `!empty`). Fixes 9 properly as `$this->_maxConcurrent` was still being overwriten.
