### PR TITLE
Fix for "Use of undefined constant CURLOPT_CONNECTTIMEOUT_MS." etc.

### DIFF
--- a/src/rollingcurlx.class.php
+++ b/src/rollingcurlx.class.php
@@ -158,8 +158,6 @@ Class RollingCurlX {
         } else {
             $options[CURLOPT_CONNECTTIMEOUT] = round($this->_timeout / 1000);
             $options[CURLOPT_TIMEOUT] = round($this->_timeout / 1000);
-            unset($options[CURLOPT_CONNECTTIMEOUT_MS]);
-            unset($options[CURLOPT_TIMEOUT_MS]);
         }
 
         if($url) {


### PR DESCRIPTION
Hello! These two lines are causing lots of warning:

Notice: Use of undefined constant CURLOPT_CONNECTTIMEOUT_MS - assumed 'CURLOPT_CONNECTTIMEOUT_MS'