### PR TITLE
Fix #41 - New feature allowing to set the connection timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Rolling Curl X is a fork of Rolling Curl wrapper cURL Multi. It aims at making c
 MIT
 
 #### Version
-3.0.0
+3.0.3
 
 #### Requirements
 PHP 5.4+
@@ -47,6 +47,9 @@ There's more if you need it though...
 ```php
 //Set a timeout on all requests:
 $RCX->setTimeout(3000); //in milliseconds
+
+//Set a connection timeout on all requests:
+$RCX->setConnectTimeout(3000); //in milliseconds
 
 //To set options for all requests(will be overridden by individual request options):
 $RCX->setOptions([$curl_options]);

--- a/src/rollingcurlx.class.php
+++ b/src/rollingcurlx.class.php
@@ -1,6 +1,6 @@
 <?php
 /*
-        ---------- RollingCurlX 3.0.2 -----------
+        ---------- RollingCurlX 3.0.3 -----------
         an easy to use curl_multi wrapper for php
 
             Copyright (c) 2015-2017 Marcus Leath
@@ -16,6 +16,7 @@ Class RollingCurlX {
     private $_headers = []; //shared cURL request headers
     private $_callback = NULL; //default callback
     private $_timeout = 5000; //all requests must be completed by this time
+    private $_connect_timeout = 5000; //all connections must be completed by this time
     public $requests = []; //request_queue
 
 
@@ -48,6 +49,12 @@ Class RollingCurlX {
     public function setTimeout($timeout) { //in milliseconds
         if($timeout > 0) {
             $this->_timeout = $timeout;
+        }
+    }
+
+    public function setConnectTimeout($connect_timeout) { //in milliseconds
+        if($connect_timeout > 0) {
+            $this->_connect_timeout = $connect_timeout;
         }
     }
 
@@ -151,12 +158,12 @@ Class RollingCurlX {
         $options[CURLOPT_NOSIGNAL] = 1;
 
         if(version_compare($this->_curl_version, '7.16.2') >= 0) {
-            $options[CURLOPT_CONNECTTIMEOUT_MS] = $this->_timeout;
+            $options[CURLOPT_CONNECTTIMEOUT_MS] = $this->_connect_timeout;
             $options[CURLOPT_TIMEOUT_MS] = $this->_timeout;
             unset($options[CURLOPT_CONNECTTIMEOUT]);
             unset($options[CURLOPT_TIMEOUT]);
         } else {
-            $options[CURLOPT_CONNECTTIMEOUT] = round($this->_timeout / 1000);
+            $options[CURLOPT_CONNECTTIMEOUT] = round($this->_connect_timeout / 1000);
             $options[CURLOPT_TIMEOUT] = round($this->_timeout / 1000);
             unset($options[CURLOPT_CONNECTTIMEOUT_MS]);
             unset($options[CURLOPT_TIMEOUT_MS]);


### PR DESCRIPTION
See issue #41 :

>the `$RCX->setTimeout(3000);` doesn't seem to work, the total execution time of the script is ~5 seconds with or without the timeout

It's because of the addition of connect timeout and timeout. The [/src/rollingcurlx.class.php lines 153 to 163](https://github.com/marcushat/RollingCurlX/blob/master/src/rollingcurlx.class.php#L153-L163) set both options to the value of the property `_timeout`. So, the max total time for a request is `_timeout * 2`. 

This is a simple fix to allow users to set the timeout and the connection timeout. 
